### PR TITLE
replace publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Update Changelog and Publish
 
 on:
   release:
-    types: [created,published]
+    types: [published]
 
 jobs:
   update:
@@ -43,8 +43,15 @@ jobs:
         run: |
           dart pub publish --dry-run
 
+      # - name: publish m3o-dart package
+      #   uses: k-paxian/dart-package-publisher@master
+      #   with:
+      #     accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
+      #     refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+
       - name: publish m3o-dart package
-        uses: k-paxian/dart-package-publisher@master
+        uses: sakebook/actions-flutter-pub-publisher@v1.4.0
         with:
-          accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
-          refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+          credential: ${{ secrets.CREDENTIAL_JSON }}
+          skip_test: true
+    


### PR DESCRIPTION
Signed-off-by: Daniel Joudat <danieljoudat@gmail.com>

Replaced the publish action we used before with one that uses flutter 2.10.3 and that should be good.

**NOTE** that this action needs contents of the file `pub-credentials.json` to be saved as a secrets, see https://github.com/marketplace/actions/publish-dart-flutter-package